### PR TITLE
GITHUB_TOKEN not needed for every make invocation

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -1,11 +1,64 @@
+#-----------------------------------------------------------------------
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corporation 2020.
+#
+# US Government Users Restricted Rights - Use, duplication or disclosure
+# restricted by GSA ADP Schedule Contract with IBM Corporation.
+#-----------------------------------------------------------------------
+
+DOCKER_USERNAME ?=
+DOCKER_PASSWORD ?=
 TARGET_DOCKER_REGISTRY ?=
 
+CONFIG_FOLDER := "dockerTmp"
+PLATFORMS ?= "amd64 ppc64le s390x"
 
-## Login to private container registry $(TARGET_DOCKER_REGISTRY) as $(DOCKER_USERNAME) $(DOCKER_PASSWORD)
+# Builds a "fat" (multi-platform) Docker manifest.
+#
+# Variables:
+#   DOCKER_USERNAME
+#     The user name with which to log in to the registry.
+#   DOCKER_PASSWORD
+#     The password for the Docker user name.
+#   IMAGE_NAME
+#     The name of the Docker image.  This is often of the
+#     form "registry/image:tag".
+#   PLATFORMS
+#     The platforms to include in the manifest.  Default:
+#     "amd64 ppc64le s290x".
+#   TARGET_DOCKER_REGISTRY
+#     The name of the Docker registry.
+.PHONY: docker/fatmanifest/build
+docker/fatmanifest/build: $(DOCKER) docker/fatmanifest/config
+	$(call assert-set,DOCKER)
+	$(call assert-set,DOCKER_USERNAME)
+	$(call assert-set,DOCKER_PASSWORD)
+	$(call assert-set,IMAGE_NAME)
+	$(call assert-set,PLATFORMS)
+	$(call assert-set,TARGET_DOCKER_REGISTRY)
+	x = foreach(platform, PLATFORMS, "IMAGE_NAME-$(platform) ")
+	echo CJB $(x)
+
+# Logs in to a Docker registry.
+#
+# Variables:
+#   DOCKER_USERNAME
+#     The user name with which to log in to the registry.
+#   DOCKER_PASSWORD
+#     The password for the Docker user name.
+#   TARGET_DOCKER_REGISTRY
+#     The name of the Docker registry.
 .PHONY: docker/registry/login
 docker/registry/login: $(DOCKER)
 	$(call assert-set,DOCKER)
-	$(call assert-set,TARGET_DOCKER_REGISTRY)
 	$(call assert-set,DOCKER_USERNAME)
 	$(call assert-set,DOCKER_PASSWORD)
+	$(call assert-set,TARGET_DOCKER_REGISTRY)
 	@$(DOCKER) login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD) $(TARGET_DOCKER_REGISTRY)
+
+# Helper targets:
+.PHONY: docker/fatmanifest/config
+docker/fatmanifest/config:
+	mkdir -p $(CONFIG_FOLDER)
+    echo '{ \"experimental\": \"enabled\" }' > $(CONFIG_FOLDER)/config.json

--- a/modules/go-ext/Makefile
+++ b/modules/go-ext/Makefile
@@ -21,7 +21,7 @@ SOURCE_DIR ?= $(pwd)
 #     Typically, the parent directory containing PACKAGES.  This target
 #     will switch to SOURCE_DIR before building the packages.  Default:
 #     the current working directory.
-go-ext/build: $(GO)
+go/ext/build: $(GO)
 	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) build $(PACKAGES)
@@ -31,7 +31,7 @@ go-ext/build: $(GO)
 # Variables:
 #   PACKAGES:
 #     One or more packages to get.  Example:  PACKAGES=github.com/fsnotify/fsnotify
-go-ext/get: $(GO)
+go/ext/get: $(GO)
 	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	$(GO) get -u -v $(PACKAGES)
@@ -45,7 +45,7 @@ go-ext/get: $(GO)
 #     Typically, the parent directory containing PACKAGES.  This target
 #     will switch to SOURCE_DIR before installing the packages.  Default:
 #     the current working directory.
-go-ext/install: $(GO)
+go/ext/install: $(GO)
 	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) install $(PACKAGES)
@@ -61,7 +61,7 @@ go-ext/install: $(GO)
 #     Typically, the parent directory containing PACKAGES.  This target
 #     will switch to SOURCE_DIR before building the packages.  Default:
 #     the current working directory.
-go-ext/test: $(GO)
+go/ext/test: $(GO)
 	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) test -count=$(COUNT) $(PACKAGES)

--- a/modules/go-ext/Makefile
+++ b/modules/go-ext/Makefile
@@ -22,6 +22,7 @@ SOURCE_DIR ?= $(pwd)
 #     will switch to SOURCE_DIR before building the packages.  Default:
 #     the current working directory.
 go-ext/build: $(GO)
+	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) build $(PACKAGES)
 
@@ -31,6 +32,7 @@ go-ext/build: $(GO)
 #   PACKAGES:
 #     One or more packages to get.  Example:  PACKAGES=github.com/fsnotify/fsnotify
 go-ext/get: $(GO)
+	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	$(GO) get -u -v $(PACKAGES)
 
@@ -44,6 +46,7 @@ go-ext/get: $(GO)
 #     will switch to SOURCE_DIR before installing the packages.  Default:
 #     the current working directory.
 go-ext/install: $(GO)
+	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) install $(PACKAGES)
 
@@ -59,5 +62,6 @@ go-ext/install: $(GO)
 #     will switch to SOURCE_DIR before building the packages.  Default:
 #     the current working directory.
 go-ext/test: $(GO)
+	$(call assert-set,GO)
 	$(call assert-set,PACKAGES)
 	cd $(SOURCE_DIR) && $(GO) test -count=$(COUNT) $(PACKAGES)


### PR DESCRIPTION
The GITHUB_TOKEN is only needed to download .BuildHarnessConfig.global from github.  This change tests if the file exists and, if so, does not check for GITHUB_TOKEN and does not download the file again, which should speed up the build.