### PR TITLE
add feature docker image build and push based on current branch name

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -91,6 +91,15 @@ docker/image/tag-and-push:
 	@$(SELF) -s docker/image/push TARGET_VERSION=$(TARGET_VERSION_ARCH)
 	@$(SELF) -s docker/image/push TARGET_VERSION=$(TARGET_VERSION_LATEST)
 
+
+docker/image/feature/build-and-push:
+        $(call assert-set,DOCKER)
+        $(call assert-set,DOCKER_USERNAME)
+        $(call assert-set,DOCKER_PASSWORD)
+        $(call assert-set,TARGET_DOCKER_REGISTRY)
+        $(SELF) docker/build TARGET_VERSION:=$(shell git rev-parse --abbrev-ref HEAD)
+        @$(SELF) -s docker/image/push TARGET_VERSION=$(shell git rev-parse --abbrev-ref HEAD)
+
 # Logs in to a Docker registry.
 #
 # Variables:

--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -91,7 +91,7 @@ docker/image/tag-and-push:
 	@$(SELF) -s docker/image/push TARGET_VERSION=$(TARGET_VERSION_ARCH)
 	@$(SELF) -s docker/image/push TARGET_VERSION=$(TARGET_VERSION_LATEST)
 
-
+.PHONY: docker/image/feature/build-and-push
 docker/image/feature/build-and-push:
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_USERNAME)

--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -93,12 +93,12 @@ docker/image/tag-and-push:
 
 
 docker/image/feature/build-and-push:
-        $(call assert-set,DOCKER)
-        $(call assert-set,DOCKER_USERNAME)
-        $(call assert-set,DOCKER_PASSWORD)
-        $(call assert-set,TARGET_DOCKER_REGISTRY)
-        $(SELF) docker/build TARGET_VERSION:=$(shell git rev-parse --abbrev-ref HEAD)
-        @$(SELF) -s docker/image/push TARGET_VERSION=$(shell git rev-parse --abbrev-ref HEAD)
+	$(call assert-set,DOCKER)
+	$(call assert-set,DOCKER_USERNAME)
+	$(call assert-set,DOCKER_PASSWORD)
+	$(call assert-set,TARGET_DOCKER_REGISTRY)
+	$(SELF) docker/build TARGET_VERSION:=$(shell git rev-parse --abbrev-ref HEAD)
+	@$(SELF) -s docker/image/push TARGET_VERSION=$(shell git rev-parse --abbrev-ref HEAD)
 
 # Logs in to a Docker registry.
 #

--- a/templates/Makefile.build-harness-bootstrap
+++ b/templates/Makefile.build-harness-bootstrap
@@ -11,7 +11,7 @@ export BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || 
 -include $(BUILD_HARNESS_PATH)/Makefile
 export BUILD_HARNESS_EXTENSIONS_HOST ?= github.com
 export BUILD_HARNESS_EXTENSIONS_HOST_AUTH ?= false
-export BUILD_HARNESS_EXTENSIONS_ORG ?= multicloud-ops
+export BUILD_HARNESS_EXTENSIONS_ORG ?= zshearin 
 export BUILD_HARNESS_EXTENSIONS_PROJECT ?= build-harness-extensions
 export BUILD_HARNESS_EXTENSIONS_BRANCH ?= master
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_EXTENSIONS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)

--- a/templates/Makefile.build-harness-bootstrap
+++ b/templates/Makefile.build-harness-bootstrap
@@ -11,7 +11,7 @@ export BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || 
 -include $(BUILD_HARNESS_PATH)/Makefile
 export BUILD_HARNESS_EXTENSIONS_HOST ?= github.com
 export BUILD_HARNESS_EXTENSIONS_HOST_AUTH ?= false
-export BUILD_HARNESS_EXTENSIONS_ORG ?= zshearin
+export BUILD_HARNESS_EXTENSIONS_ORG ?= multicloud-ops
 export BUILD_HARNESS_EXTENSIONS_PROJECT ?= build-harness-extensions
 export BUILD_HARNESS_EXTENSIONS_BRANCH ?= master
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_EXTENSIONS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)

--- a/templates/Makefile.build-harness-bootstrap
+++ b/templates/Makefile.build-harness-bootstrap
@@ -11,7 +11,7 @@ export BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || 
 -include $(BUILD_HARNESS_PATH)/Makefile
 export BUILD_HARNESS_EXTENSIONS_HOST ?= github.com
 export BUILD_HARNESS_EXTENSIONS_HOST_AUTH ?= false
-export BUILD_HARNESS_EXTENSIONS_ORG ?= zshearin 
+export BUILD_HARNESS_EXTENSIONS_ORG ?= zshearin
 export BUILD_HARNESS_EXTENSIONS_PROJECT ?= build-harness-extensions
 export BUILD_HARNESS_EXTENSIONS_BRANCH ?= master
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_EXTENSIONS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_EXTENSIONS_PROJECT)


### PR DESCRIPTION
This is intended to build a "throw away" feature image for an operator or operand image to facilitate running fvt tests prior to merging master.  

This can also be done by modifying my own local Makefile, but this likely is the way I think several squads that dev in the monitoring operator would ideally use for validating purposes (it would be run in addition to unit testing prior to code reaching master).  Right now, for the metricsvc-operator, it will be used to run the k8s job fvt against feature dev work 