### PR TITLE
add change image back and forth

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -18,6 +18,13 @@ TARGET_VERSION_LATEST ?= $(SEMVERSION_MAJOR_MINOR)-latest
 
 DOCKER_IMAGE_LATEST ?= $(TARGET_DOCKER_REGISTRY)/$(IMAGE_NAME):$(TARGET_VERSION_LATEST)
 
+OPERATOR_YAML := deploy/operator.yaml
+TAG_FOR_DEV := $(shell git rev-parse --abbrev-ref HEAD)
+#Old image tag we want to change
+O=$(APP):latest
+#New image tag to change to
+N=$(APP):$(TAG_FOR_DEV)
+
 # Builds an architecture-specific Docker image.
 #
 # Variables:
@@ -99,6 +106,15 @@ docker/image/feature/build-and-push:
 	$(call assert-set,TARGET_DOCKER_REGISTRY)
 	$(SELF) docker/build TARGET_VERSION:=$(shell git rev-parse --abbrev-ref HEAD)
 	@$(SELF) -s docker/image/push TARGET_VERSION=$(shell git rev-parse --abbrev-ref HEAD)
+
+.PHONY: docker/image/feature/change-image
+docker/image/feature/change-image:
+        sed -i "s|$O|$N|" $(OPERATOR_YAML)
+
+.PHONY: docker/image/feature/change-image-back
+docker/image/feature/change-image-back:
+        sed -i "s|$N|$O|" $(OPERATOR_YAML)
+
 
 # Logs in to a Docker registry.
 #


### PR DESCRIPTION
This is what I am currently using to test bvt of a feature branch.  This one is not as clear-cut as to what we want to do (feedback to potentially change would be greatly appreciated), but I have found this useful and have been using it locally.

Two assumptions this makes: 
1. the `APP` variable is defined in your `BuildHarnessConfig.local` file and it is the same as your current repo operator name (or operand repo name)

2. your operator yaml file lives in directory `deploy/operator.yaml` - this I believe will change in future versions of the operator-sdk, that's why I thought it makes sense to have it defined above instead of in-line

This make target would also just be used for feature branch builds prior to promoting to master.  What I am currently doing is this (in my feature dev test):

build/push
change-image
deploy
test (k8s job runs container and completes if successful, errors if not)
change-image-back
delete (deployment and fvt job - unless it failed then leave it to be able to debug results)

This is just another common function that would also make scratch deployments a little easier (specifically for monitoring squads)